### PR TITLE
actually throw the exception we generate

### DIFF
--- a/lib/FFI/TinyCC.pm
+++ b/lib/FFI/TinyCC.pm
@@ -498,7 +498,7 @@ sub get_symbol
     my $size = _relocate($self, undef);
     $self->{store} = malloc($size);
     my $r = _relocate($self, $self->{store});
-    FFI::TinyCC::Exception->new($self) if $r == -1;
+    die FFI::TinyCC::Exception->new($self) if $r == -1;
     $self->{relocate} = 1;
   }
   _get_symbol($self, $symbol_name);


### PR DESCRIPTION
I ran into this issue, but stupidly edited the code afterwards and now can't reproduce it. Still, it's an obvious enough change.

Will try again to find a test case.